### PR TITLE
[BE] 이슈 삭제 기능 구현

### DIFF
--- a/be/src/main/java/com/codesquad/issuetracker/api/issue/controller/IssueController.java
+++ b/be/src/main/java/com/codesquad/issuetracker/api/issue/controller/IssueController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,4 +27,11 @@ public class IssueController {
                 .body(Map.of("id", issueId));
     }
 
+    @DeleteMapping("/api/{organizationTitle}/issues/{issueId}")
+    public ResponseEntity<Void> deleteOne(@PathVariable String organizationTitle, @PathVariable Long issueId) {
+        // TODO: 로그인 관련 처리 필요
+        issueService.deleteOne(issueId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+    }
 }

--- a/be/src/main/java/com/codesquad/issuetracker/api/issue/repository/IssueRepository.java
+++ b/be/src/main/java/com/codesquad/issuetracker/api/issue/repository/IssueRepository.java
@@ -7,7 +7,10 @@ import java.util.Optional;
 public interface IssueRepository {
 
     Optional<Long> countIssuesBy(Long organizationId);
+
     Optional<Long> save(Issue issue);
+
     void save(List<?> options);
 
+    void delete(Long issueId);
 }

--- a/be/src/main/java/com/codesquad/issuetracker/api/issue/repository/IssueRepositoryImpl.java
+++ b/be/src/main/java/com/codesquad/issuetracker/api/issue/repository/IssueRepositoryImpl.java
@@ -3,9 +3,11 @@ package com.codesquad.issuetracker.api.issue.repository;
 import com.codesquad.issuetracker.api.issue.domain.Issue;
 import com.codesquad.issuetracker.api.issue.domain.IssueAssignee;
 import com.codesquad.issuetracker.api.issue.domain.IssueLabel;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -13,8 +15,10 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
+@RequiredArgsConstructor
 public class IssueRepositoryImpl implements IssueRepository {
 
     private final NamedParameterJdbcTemplate template;
@@ -59,6 +63,20 @@ public class IssueRepositoryImpl implements IssueRepository {
     private void saveIssueLabels(List<?> issueLabels) {
         String sql = "INSERT INTO issue_label (issue_id, label_id) VALUES (:issueId, :labelId)";
         template.batchUpdate(sql, SqlParameterSourceUtils.createBatch(issueLabels));
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long issueId) {
+        String queryForDeleteIssue = "DELETE FROM issue WHERE id = :issueId";
+        String queryForDeleteIssueAssignees = "DELETE FROM issue_assignee WHERE issue_id = :issueId";
+        String queryForDeleteIssueLabels = "DELETE FROM issue_label WHERE issue_id = :issueId";
+
+        Map<String, Long> param = Collections.singletonMap("issueId", issueId);
+
+        template.update(queryForDeleteIssue, param);
+        template.update(queryForDeleteIssueAssignees, param);
+        template.update(queryForDeleteIssueLabels, param);
     }
 
 }

--- a/be/src/main/java/com/codesquad/issuetracker/api/issue/service/IssueService.java
+++ b/be/src/main/java/com/codesquad/issuetracker/api/issue/service/IssueService.java
@@ -55,4 +55,9 @@ public class IssueService {
         issueRepository.save(issueLabels);
     }
 
+    @Transactional
+    public void deleteOne(Long issueId) {
+        issueRepository.delete(issueId);
+        commentRepository.delete(issueId);
+    }
 }


### PR DESCRIPTION
## 🔑 Key changes
- [X] 이슈 삭제 시, 이슈 테이블 내 정보 삭제 #49 
- [X] 이슈 삭제 시, 해당 이슈와 연결된 마일스톤/코멘트/라벨/담당자 테이블의 정보 삭제

## 👋 To reviewers
